### PR TITLE
Experiment with async and cancel instead of forkIO and killThread

### DIFF
--- a/skeletor.cabal
+++ b/skeletor.cabal
@@ -23,8 +23,9 @@ library
                      , Control.DivideAndConquer
                      , Control.Parallel
                      , Utils
-  build-depends:       base >= 4.7 && < 5
-                     , abstract-deque >= 0.3
+  build-depends:       abstract-deque >= 0.3
+                     , async
+                     , base >= 4.7 && < 5
                      , monad-par >= 0.3
                      , random >= 1.1
                      , vector
@@ -39,6 +40,7 @@ executable skeletor-exe
                      , Utils
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N4 -ddump-simpl
   build-depends:       abstract-deque
+                     , async
                      , base
                      , monad-par
                      , parallel

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -1,5 +1,6 @@
 module Utils where
 
+import Control.Concurrent.Async
 import GHC.Conc
 
 partitionM :: Monad m => (a -> m Bool) -> [a] -> m ([a], [a])
@@ -12,3 +13,6 @@ partitionM f (x:xs) = do
 
 killThreads :: Foldable t => t ThreadId -> IO ()
 killThreads = mapM_ killThread
+
+killAsyncs :: (Functor t, Foldable t) => t (Async a) -> IO ()
+killAsyncs = mapM_ cancel


### PR DESCRIPTION
Inspired by https://mazzo.li/posts/threads-resources.html

Surprisingly the numbers have suffered. Merge sort on a vector of 100,000 elements

Run 1 with 2 threads
```
real	0m33.765s
user	0m39.330s
sys	0m3.318s
```

Run 2 with 4 threads
```
real	0m38.964s
user	1m9.043s
sys	0m13.060s
```